### PR TITLE
chords preload in hidden html; no more delay

### DIFF
--- a/javascripts/controllers/ComposerCtrl.js
+++ b/javascripts/controllers/ComposerCtrl.js
@@ -72,111 +72,159 @@ app.controller("ComposerCtrl", function($q, $scope, $rootScope, $location, Compo
 
 
 		/*The following chord#Player functions:
-			(1) Play each chord one after the other (using addEventListener):
+			(1) Determine which chords to play,
 			(2) Add/Remove glowBox classes as each chord plays
 		*/
 		let chord4Player = function(){
+			var nextChord;
+				let playNextChord = function(){
+					nextChord = setTimeout(function(){chord1Player();},1970);
+				};
+				let stopNextChord = function(){
+					clearTimeout(nextChord);
+				};
+			playNextChord();			
+
+
 			if (chord4 == "I" || chord4 == "II" || chord4 == "III" || chord4 == "IV" || chord4 == "V" || chord4 == "VI") {
 				console.log("4th Chord is Major: ", chord4);
 				var audio4Major = new Audio("audio/composerChords/"+chord4+".mp3");
 				audio4Major.play();
+				
 				angular.element(document.querySelector('.newChordInput3')).removeClass("glowBox");
 				angular.element(document.querySelector('.newChordInput4')).addClass("glowBox");
-				audio4Major.addEventListener('ended', chord1Player);
 
 				$scope.pauseProgression = function(){		
 					$scope.revealPlayOrPause = false;
 					audio4Major.pause();
+					stopNextChord();
 				};
 
 			} else {
 				console.log("4th Chord is minor: ", chord4);
 				var audio4Minor = new Audio("audio/composerChords/minor-"+chord4+".mp3");
 				audio4Minor.play();
+				
 				angular.element(document.querySelector('.newChordInput3')).removeClass("glowBox");
 				angular.element(document.querySelector('.newChordInput4')).addClass("glowBox");
-				audio4Minor.addEventListener('ended', chord1Player);
-
+				
 				$scope.pauseProgression = function(){		
 					$scope.revealPlayOrPause = false;
 					audio4Minor.pause();
+					stopNextChord();
 				};
 			}
 		};
 
 
 		let chord3Player = function(){
+			var nextChord;
+				let playNextChord = function(){
+					nextChord = setTimeout(function(){chord4Player();},1970);
+				};
+				let stopNextChord = function(){
+					clearTimeout(nextChord);
+				};
+			playNextChord();			
+
+
 			if (chord3 == "I" || chord3 == "II" || chord3 == "III" || chord3 == "IV" || chord3 == "V" || chord3 == "VI") {
 				console.log("3rd Chord is Major: ", chord3);
 				var audio3Major = new Audio("audio/composerChords/"+chord3+".mp3");
 				audio3Major.play();
+				
 				angular.element(document.querySelector('.newChordInput2')).removeClass("glowBox");
 				angular.element(document.querySelector('.newChordInput3')).addClass("glowBox");
-				audio3Major.addEventListener('ended', chord4Player);
+				
 
 				$scope.pauseProgression = function(){		
 					$scope.revealPlayOrPause = false;
 					audio3Major.pause();
+					stopNextChord();
 				};
 
 			} else {
 				console.log("3rd Chord is minor: ", chord3);
 				var audio3Minor = new Audio("audio/composerChords/minor-"+chord3+".mp3");
 				audio3Minor.play();
+				
 				angular.element(document.querySelector('.newChordInput2')).removeClass("glowBox");
 				angular.element(document.querySelector('.newChordInput3')).addClass("glowBox");
-				audio3Minor.addEventListener('ended', chord4Player);
+				
 
 				$scope.pauseProgression = function(){		
 					$scope.revealPlayOrPause = false;
 					audio3Minor.pause();
+					stopNextChord();
 				};
 			}
 		};
 
 
 		let chord2Player = function(){
+			var nextChord;
+				let playNextChord = function(){
+					nextChord = setTimeout(function(){chord3Player();},1970);
+				};
+				let stopNextChord = function(){
+					clearTimeout(nextChord);
+				};
+			playNextChord();
+
+
 			if (chord2 == "I" || chord2 == "II" || chord2 == "III" || chord2 == "IV" || chord2 == "V" || chord2 == "VI") {
 				console.log("2nd Chord is Major: ", chord2);
 				var audio2Major = new Audio("audio/composerChords/"+chord2+".mp3");
 				audio2Major.play();
+				
 				angular.element(document.querySelector('.newChordInput1')).removeClass("glowBox");
 				angular.element(document.querySelector('.newChordInput2')).addClass("glowBox");
-				audio2Major.addEventListener('ended', chord3Player);
-
+				
 				$scope.pauseProgression = function(){		
 					$scope.revealPlayOrPause = false;
 					audio2Major.pause();
+					stopNextChord();
 				};
 
 			} else {
 				console.log("2nd Chord is minor: ", chord2);
 				var audio2Minor = new Audio("audio/composerChords/minor-"+chord2+".mp3");
 				audio2Minor.play();
+				
 				angular.element(document.querySelector('.newChordInput1')).removeClass("glowBox");
 				angular.element(document.querySelector('.newChordInput2')).addClass("glowBox");
-				audio2Minor.addEventListener('ended', chord3Player);
 
 				$scope.pauseProgression = function(){		
 					$scope.revealPlayOrPause = false;
 					audio2Minor.pause();
+					stopNextChord();
 				};
 			}
 		};
 
 
 		let chord1Player = function(){
+			var nextChord;
+				let playNextChord = function(){
+					nextChord = setTimeout(function(){chord2Player();},1970);
+				};
+				let stopNextChord = function(){
+					clearTimeout(nextChord);
+				};
+			playNextChord();			
+
 			if (chord1 == "I" || chord1 == "II" || chord1 == "III" || chord1 == "IV" || chord1 == "V" || chord1 == "VI") {
 				console.log("1st Chord is Major: ", chord1);
 				var audio1Major = new Audio('audio/composerChords/'+chord1+'.mp3');
 				audio1Major.play();
+				
 				angular.element(document.querySelector('.newChordInput4')).removeClass("glowBox");
 				angular.element(document.querySelector('.newChordInput1')).addClass("glowBox");
-				audio1Major.addEventListener('ended', chord2Player);
 
 				$scope.pauseProgression = function(){		
 					$scope.revealPlayOrPause = false;
 					audio1Major.pause();
+					stopNextChord();
 				};
 
 				
@@ -184,17 +232,19 @@ app.controller("ComposerCtrl", function($q, $scope, $rootScope, $location, Compo
 				console.log("1st Chord is minor: ", chord1);
 				var audio1Minor = new Audio('audio/composerChords/minor-'+chord1+'.mp3');
 				audio1Minor.play();
+				
 				angular.element(document.querySelector('.newChordInput4')).removeClass("glowBox");
 				angular.element(document.querySelector('.newChordInput1')).addClass("glowBox");
-				audio1Minor.addEventListener('ended', chord2Player);
-
+				
 				$scope.pauseProgression = function(){		
 					$scope.revealPlayOrPause = false;
 					audio1Minor.pause();
+					stopNextChord();
 				};
-			}
+			}	
 		};
 		chord1Player();
+
 
 
 

--- a/partials/chordcomposer.html
+++ b/partials/chordcomposer.html
@@ -17,8 +17,7 @@
 		<button type="button" class="btn btn-primary btn-sm" ng-click="addNewProgression(newProgression); glowBoxes()">Save Chord Progression</button>
 	</div>
 
-
-
+	
 	<hr/>
 	<h3>Saved Chord Progressions</h3>
 	<hr/>
@@ -35,6 +34,26 @@
 			
 			<button type="button" class="btn btn-danger btn-sm" ng-click="deleteProgression(chordProgression.id)">Delete</button>
 		</div>
+	</div>
+
+	<!--Audio Files preloaded so there is no delay in the timing of playProgression()-->
+	<div ng-hide="true">
+		<audio preload="auto">
+			<source src="audio/composerChords/I.mp3">
+			<source src="audio/composerChords/II.mp3">
+			<source src="audio/composerChords/III.mp3">
+			<source src="audio/composerChords/IV.mp3">
+			<source src="audio/composerChords/V.mp3">
+			<source src="audio/composerChords/VI.mp3">
+
+			<source src="audio/composerChords/minor-i.mp3">
+			<source src="audio/composerChords/minor-ii.mp3">
+			<source src="audio/composerChords/minor-iii.mp3">
+			<source src="audio/composerChords/minor-iv.mp3">
+			<source src="audio/composerChords/minor-v.mp3">
+			<source src="audio/composerChords/minor-vi.mp3">
+			<source src="audio/composerChords/minor-vii.mp3">
+		</audio>
 	</div>
 
 </div>


### PR DESCRIPTION
The issue was that chord1Player() took a split second to load in the first file, but chord2Player() was triggered to a timer that wasn't affected by the delay... resulting in the 2nd chord being "rushed" in during the very first play through. Having the files preloaded in the html seems to be the easiest ways to solve the problem.